### PR TITLE
Allow custom styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ dismissOnScroll:          React.PropTypes.bool, // true by default!
 dismissOnScrollThreshold: React.PropTypes.number, // defaults to 0
 closeIcon:                React.PropTypes.string, // this should be the className of the icon. if undefined use button
 disableStyle:             React.PropTypes.bool,
+styles:                   React.PropTypes.object, // override styles
 className:                React.PropTypes.string,
 children:                 React.PropTypes.element // rendered in replacement without any <div> wrapper
 ```
@@ -72,6 +73,12 @@ You can also pass your own CustomCookieBanner as child component which will be r
   <CustomCookieBanner {...myCustomProps} /> // rendered directly without any <div> wrapper
 </CookieBanner>
 ```
+Or you override the predefined inline-styles. This examples puts the message font back to normal weight and makes the banner slightly transparent:
+```jsx
+<CookieBanner styles={{banner: {backgroundColor: 'rgba(60, 60, 60, 0.8)'}, 
+  message: {fontWeight: 400}}} message="..." />
+```
+See `src/styleUtils.js` for which style objects are availble to be overridden.
 
 ###Cookie manipulation
 ReactCookieBanner uses and exports the library **```browser-cookie-lite```**

--- a/src/CookieBanner.js
+++ b/src/CookieBanner.js
@@ -17,6 +17,7 @@ const CookieBanner = React.createClass({
     dismissOnScrollThreshold: React.PropTypes.number,
     closeIcon:                React.PropTypes.string,
     disableStyle:             React.PropTypes.bool,
+    styles:                   React.PropTypes.object,
     children:                 React.PropTypes.element
   },
   /*eslint-enable */
@@ -62,7 +63,12 @@ const CookieBanner = React.createClass({
 
   getStyle(style) {
     if (!this.props.disableStyle) {
-      return styleUtils.getStyle(style);
+      let styles = styleUtils.getStyle(style);
+      // apply custom styles if available
+      if (this.props.styles && this.props.styles[style]) {
+        Object.assign(styles, this.props.styles[style]);
+      }
+      return styles;
     }
   },
 


### PR DESCRIPTION
```
<CookieBanner styles={{message: {fontWeight: 400}}} message="..." />
```
overrides the fontWeight property of the message style and sets it to
normal weight.

See `src/styleUtils.js` for the base style objects to override.

Updated README for custom styling