### PR TITLE
#23: Cookie expiration date (closes #23)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "./node_modules/karma/bin/karma start",
     "build": "rm -rf lib && mkdir lib && babel --loose --stage 0 --out-dir lib src",
-    "lint": "eslint src",
+    "lint": "eslint src test",
     "preversion": "npm run lint && npm run test && npm run build-examples",
     "prepublish": "npm run build",
     "build-examples": "npm run clean && webpack --config examples/webpack.config.build.js --progress",

--- a/src/CookieBanner.js
+++ b/src/CookieBanner.js
@@ -17,11 +17,14 @@ const Props = {
   })),
   buttonMessage: t.maybe(t.String),
   cookie: t.maybe(t.String),
-  cookieExpiration: t.maybe(t.union([t.interface({
-    years: t.maybe(t.Number),
-    days: t.maybe(t.Number),
-    hours: t.maybe(t.Number)
-  }), t.Integer])),
+  cookieExpiration: t.maybe(t.union([
+    t.Integer,
+    t.interface({
+      years: t.maybe(t.Number),
+      days: t.maybe(t.Number),
+      hours: t.maybe(t.Number)
+    })
+  ])),
   dismissOnScroll: t.maybe(t.Boolean),
   dismissOnScrollThreshold: t.maybe(t.Number),
   closeIcon: t.maybe(t.String),

--- a/src/CookieBanner.js
+++ b/src/CookieBanner.js
@@ -4,12 +4,13 @@ import omit from 'lodash.omit';
 import { t, props } from 'tcomb-react';
 import { cookie as cookieLite } from 'browser-cookie-lite';
 import styleUtils from './styleUtils';
+t.interface.strict = true;
 
 const Props = {
   children: t.maybe(t.ReactChildren),
   message: t.maybe(t.String),
   onAccept: t.maybe(t.Function),
-  link: t.maybe(t.struct({
+  link: t.maybe(t.interface({
     msg: t.maybe(t.String),
     url: t.String,
     target: t.maybe(t.enums.of(['_blank', '_self', '_parent', '_top', 'framename']))

--- a/test/tests/CookieBanner-test.js
+++ b/test/tests/CookieBanner-test.js
@@ -30,6 +30,24 @@ const renderBanner = (props) => {
 
 beforeEach(resetCookies);
 
+describe('secondsSinceExpiration', () => {
+  const { getSecondsSinceExpiration } = new CookieBanner();
+
+  it('should return "cookieExpiration" if it is an integer', () => {
+    expect(getSecondsSinceExpiration(12345)).toBe(12345);
+  });
+
+  it('should transform "years", "days" and "hours" into seconds', () => {
+    expect(getSecondsSinceExpiration({ years: 1, days: 10, hours: 5 })).toBe(32418000);
+  });
+
+  it('should handle missing "years", "days" or "hours"', () => {
+    expect(getSecondsSinceExpiration({ days: 10 })).toBe(864000);
+    expect(getSecondsSinceExpiration({})).toBe(0);
+  });
+
+});
+
 describe('CookieBanner', () => {
 
   it('should be displayed if no cookies are set', () => {

--- a/test/tests/CookieBanner-test.js
+++ b/test/tests/CookieBanner-test.js
@@ -4,21 +4,22 @@ import expect from 'expect';
 import CookieBanner from '../../src/CookieBanner';
 
 const resetCookies = function () {
-  const cookies = document.cookie.split(";");
+  const cookies = document.cookie.split(';');
 
   for (let i = 0; i < cookies.length; i++) {
     const cookie = cookies[i];
-    const eqPos = cookie.indexOf("=");
+    const eqPos = cookie.indexOf('=');
     const name = eqPos > -1 ? cookie.substr(0, eqPos) : cookie;
-    document.cookie = name + "=;expires=Thu, 01 Jan 1970 00:00:00 GMT";
+    document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT`;
   }
 };
 
 const renderBanner = (props) => {
-  const component =
+  const component = (
     <div>
       <CookieBanner message='cookie message' {...props} />
-    </div>;
+    </div>
+  );
   const cookieWrapper = TestUtils.renderIntoDocument(component);
 
   return {
@@ -29,14 +30,14 @@ const renderBanner = (props) => {
 
 beforeEach(resetCookies);
 
-describe('CookieBanner', function() {
+describe('CookieBanner', () => {
 
-  it('should be displayed if no cookies are set', function() {
+  it('should be displayed if no cookies are set', () => {
     const banner = renderBanner().banner;
     expect(banner.length).toBe(1, 'cookie banner is not displayed');
   });
 
-  it('should hide on click', function() {
+  it('should hide on click', () => {
     const banner = renderBanner().banner[0];
     const closeButton = TestUtils.findRenderedDOMComponentWithClass(banner, 'button-close');
     TestUtils.Simulate.click(closeButton);
@@ -46,7 +47,7 @@ describe('CookieBanner', function() {
     expect(cookieBanner2.length).toBe(0, 'cookie banner is displayed');
   });
 
-  it('should hide on click when dismissOnScroll is false', function() {
+  it('should hide on click when dismissOnScroll is false', () => {
     const { banner, wrapper } = renderBanner({ dismissOnScroll: false });
     const closeButton = TestUtils.findRenderedDOMComponentWithClass(banner[0], 'button-close');
     TestUtils.Simulate.click(closeButton);
@@ -55,7 +56,7 @@ describe('CookieBanner', function() {
     expect(cookieBanners.length).toBe(0, 'cookie banner is displayed');
   });
 
-  it('should be displayed with correct message', function() {
+  it('should be displayed with correct message', () => {
     const cookieWrapper = TestUtils.renderIntoDocument(
       <div>
         <CookieBanner message='cookie message' />
@@ -67,7 +68,7 @@ describe('CookieBanner', function() {
     expect(message.innerHTML).toBe('cookie message', 'wrong message displayed');
   });
 
-  it('should be replaced with custom child component', function() {
+  it('should be replaced with custom child component', () => {
 
     const MyComponent = React.createClass({
       render() {
@@ -75,12 +76,13 @@ describe('CookieBanner', function() {
       }
     });
 
-    const component =
+    const component = (
       <div>
         <CookieBanner>
           <MyComponent />
         </CookieBanner>
-      </div>;
+      </div>
+    );
 
     const cookieWrapper = TestUtils.renderIntoDocument(component);
 


### PR DESCRIPTION
Issue #23

## Test Plan

### tests performed
- log `secondsSinceExpiration`
  - don't pass `cookieExpiration` --> 31536000 ✅  (default is  `{ years: 1 }`
  - pass `12345` --> `12345` ✅ 
  - pass `{ years: 1, days: 10, hours: 5 }` --> 32418000 ✅ 
  - pass `{}` --> 0 ✅ 

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
