### PR TITLE
Custom component can receive onAccept prop using a children function

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,7 +33,6 @@
     "react/no-unknown-property": 1,
     "react/react-in-jsx-scope": 1,
     "react/self-closing-comp": 1,
-    "react/wrap-multilines": 1,
-    "react/no-multi-comp": 0
+    "react/wrap-multilines": 1
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -33,6 +33,7 @@
     "react/no-unknown-property": 1,
     "react/react-in-jsx-scope": 1,
     "react/self-closing-comp": 1,
-    "react/wrap-multilines": 1
+    "react/wrap-multilines": 1,
+    "react/no-multi-comp": 0
   }
 }

--- a/src/CookieBanner.js
+++ b/src/CookieBanner.js
@@ -7,7 +7,10 @@ import styleUtils from './styleUtils';
 t.interface.strict = true;
 
 const Props = {
-  children: t.maybe(t.ReactChildren),
+  children: t.maybe(t.union([
+    t.ReactChildren,
+    t.Function
+  ])),
   message: t.maybe(t.String),
   onAccept: t.maybe(t.Function),
   link: t.maybe(t.interface({
@@ -169,6 +172,9 @@ export default class CookieBanner extends React.Component {
   getBanner = () => {
     const { children, className, message } = this.props;
     if (children) {
+      if (typeof children === 'function') {
+        return children(this.onAccept);
+      }
       return children;
     }
 

--- a/src/CookieBanner.js
+++ b/src/CookieBanner.js
@@ -172,7 +172,7 @@ export default class CookieBanner extends React.Component {
   getBanner = () => {
     const { children, className, message } = this.props;
     if (children) {
-      if (typeof children === 'function') {
+      if (t.Function.is(children)) {
         return children(this.onAccept);
       }
       return children;

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "react/no-multi-comp": 0
+  }
+}

--- a/test/tests/CookieBanner-test.js
+++ b/test/tests/CookieBanner-test.js
@@ -1,4 +1,4 @@
-import React, { PropTypes } from 'react/addons';
+import React from 'react/addons';
 const TestUtils = React.addons.TestUtils;
 import expect from 'expect';
 import CookieBanner from '../../src/CookieBanner';
@@ -108,7 +108,7 @@ describe('CookieBanner', () => {
     expect(banner.length).toBe(0, 'cookie banner is being displayed');
 
     const _myComponent = TestUtils.scryRenderedDOMComponentsWithClass(cookieWrapper, 'my-component');
-    expect(_myComponent.length).toBe(1, 'cookie banner is not displaing custom child component');
+    expect(_myComponent.length).toBe(1, 'cookie banner is not displaying custom child component');
   });
 
   it('should be replaced with custom child component using function', () => {
@@ -119,14 +119,10 @@ describe('CookieBanner', () => {
       }
     });
 
-    MyOtherComponent.propTypes = {
-      onAccept: PropTypes.func
-    };
-
     const component = (
       <div>
         <CookieBanner>
-          {(onAccept) => { return (<MyOtherComponent onAccept={onAccept} />); }}
+          {onAccept => <MyOtherComponent onAccept={onAccept} />}
         </CookieBanner>
       </div>
     );
@@ -137,7 +133,7 @@ describe('CookieBanner', () => {
     expect(banner.length).toBe(0, 'cookie banner is being displayed');
 
     const _myComponent = TestUtils.scryRenderedDOMComponentsWithClass(cookieWrapper, 'my-other-component');
-    expect(_myComponent.length).toBe(1, 'cookie banner is not displaing custom child component using function');
+    expect(_myComponent.length).toBe(1, 'cookie banner is not displaying custom child component using function');
   });
 
 });

--- a/test/tests/CookieBanner-test.js
+++ b/test/tests/CookieBanner-test.js
@@ -1,4 +1,4 @@
-import React from 'react/addons';
+import React, { PropTypes } from 'react/addons';
 const TestUtils = React.addons.TestUtils;
 import expect from 'expect';
 import CookieBanner from '../../src/CookieBanner';
@@ -109,6 +109,35 @@ describe('CookieBanner', () => {
 
     const _myComponent = TestUtils.scryRenderedDOMComponentsWithClass(cookieWrapper, 'my-component');
     expect(_myComponent.length).toBe(1, 'cookie banner is not displaing custom child component');
+  });
+
+  it('should be replaced with custom child component using function', () => {
+
+    const MyOtherComponent = React.createClass({
+      render() {
+        return <div className='my-other-component' onClick={this.props.onAccept}/>;
+      }
+    });
+
+    MyOtherComponent.propTypes = {
+      onAccept: PropTypes.func
+    };
+
+    const component = (
+      <div>
+        <CookieBanner>
+          {(onAccept) => { return (<MyOtherComponent onAccept={onAccept} />); }}
+        </CookieBanner>
+      </div>
+    );
+
+    const cookieWrapper = TestUtils.renderIntoDocument(component);
+
+    const banner = TestUtils.scryRenderedDOMComponentsWithClass(cookieWrapper, 'react-cookie-banner');
+    expect(banner.length).toBe(0, 'cookie banner is being displayed');
+
+    const _myComponent = TestUtils.scryRenderedDOMComponentsWithClass(cookieWrapper, 'my-other-component');
+    expect(_myComponent.length).toBe(1, 'cookie banner is not displaing custom child component using function');
   });
 
 });


### PR DESCRIPTION
There was no possibility to bind the onAccept callback to a custom element to dismiss the banner.

This PR solves this allowing to set a function as children with a onAccept argument.
This function must return a valid react element.
