### PR TITLE
dismissOnClick feature

### DIFF
--- a/src/CookieBanner.js
+++ b/src/CookieBanner.js
@@ -28,6 +28,7 @@ const Props = {
       hours: t.maybe(t.Number)
     })
   ])),
+  dismissOnClick: t.maybe(t.Boolean),
   dismissOnScroll: t.maybe(t.Boolean),
   dismissOnScrollThreshold: t.maybe(t.Number),
   closeIcon: t.maybe(t.String),
@@ -45,6 +46,7 @@ const Props = {
  * @param buttonMessage - message written inside the button of the default cookie banner
  * @param cookie - cookie-key used to save user's decision about you cookie-policy
  * @param cookieExpiration - used to set the cookie expiration
+ * @param dismissOnClick - whether the cookie banner should be dismissed on click anywhere
  * @param dismissOnScroll - whether the cookie banner should be dismissed on scroll or not
  * @param dismissOnScrollThreshold -
  *   amount of pixel the user need to scroll to dismiss the cookie banner
@@ -57,6 +59,7 @@ export default class CookieBanner extends React.Component {
 
   static defaultProps = {
     onAccept: () => {},
+    dismissOnClick: false,
     dismissOnScroll: true,
     cookie: 'accepts-cookies',
     cookieExpiration: { years: 1 },
@@ -181,6 +184,8 @@ export default class CookieBanner extends React.Component {
     }
 
     const props = omit(this.props, Object.keys(Props));
+    if (this.props.dismissOnClick) props.onClick = this.onAccept;
+
     const computedClassName = cx('react-cookie-banner', className);
     return (
       <div {...props} className={computedClassName} style={this.getStyle('banner')}>

--- a/src/README.md
+++ b/src/README.md
@@ -12,6 +12,7 @@ React Cookie banner dismissable with just a scroll!
 | **buttonMessage** | <code>String</code> | <code>"Got it"</code> | *optional*. Message written inside the button of the default cookie banner |
 | **cookie** | <code>String</code> | <code>"accepts-cookies"</code> | *optional*. Cookie-key used to save user's decision about you cookie-policy |
 | **cookieExpiration** | <code>union(Integer &#124; {years: ?Number, days: ?Number, hours: ?Number})</code> | <code>{   "years": 1 }</code> | *optional*. Used to set the cookie expiration |
+| **dismissOnClick** | <code>Boolean</code> | <code>false</code> | *optional*. Whether the cookie banner should be dismissed with a click anywhere on its contents |
 | **dismissOnScroll** | <code>Boolean</code> | <code>true</code> | *optional*. Whether the cookie banner should be dismissed on scroll or not |
 | **dismissOnScrollThreshold** | <code>Number</code> | <code>0</code> | *optional*.   amount of pixel the user need to scroll to dismiss the cookie banner |
 | **closeIcon** | <code>String</code> |  | *optional*. ClassName passed to close-icon |


### PR DESCRIPTION
This is a proposal for a `dismissOnClick` feature which would allow a click anywhere in the whole banner to dismiss it.

My use case: I'm can't use `dismissOnScroll`, but correctly clicking on an small icon can actually be kinda hard on mobile, so I'd like the banner to be more easily dismissable,.