### PR TITLE
Add a 'cookiePath' property

### DIFF
--- a/src/CookieBanner.js
+++ b/src/CookieBanner.js
@@ -21,6 +21,7 @@ const Props = {
       hours: t.maybe(t.Number)
     })
   ])),
+  cookiePath: t.maybe(t.String),
   dismissOnScroll: t.maybe(t.Boolean),
   dismissOnScrollThreshold: t.maybe(t.Number)
 };
@@ -34,6 +35,7 @@ const Props = {
  * @param buttonMessage - message written inside the button of the default cookie banner
  * @param cookie - cookie-key used to save user's decision about you cookie-policy
  * @param cookieExpiration - used to set the cookie expiration
+ * @param cookiePath - used to set the cookie path
  * @param dismissOnScroll - whether the cookie banner should be dismissed on scroll or not
  * @param dismissOnScrollThreshold -
  *   amount of pixel the user need to scroll to dismiss the cookie banner
@@ -112,9 +114,9 @@ export default class CookieBanner extends React.Component {
   }
 
   onAccept = () => {
-    const { cookie, cookieExpiration, onAccept } = this.props;
+    const { cookie, cookieExpiration, cookiePath, onAccept } = this.props;
 
-    cookieLite(cookie, true, this.getSecondsSinceExpiration(cookieExpiration));
+    cookieLite(cookie, true, this.getSecondsSinceExpiration(cookieExpiration), cookiePath);
     onAccept({ cookie });
 
     if (this.state.listeningScroll) {

--- a/src/README.md
+++ b/src/README.md
@@ -12,6 +12,7 @@ React Cookie banner dismissable with just a scroll!
 | **buttonMessage** | <code>String</code> | <code>"Got it"</code> | *optional*. Message written inside the button of the default cookie banner |
 | **cookie** | <code>String</code> | <code>"accepts-cookies"</code> | *optional*. Cookie-key used to save user's decision about you cookie-policy |
 | **cookieExpiration** | <code>union(Integer &#124; {years: ?Number, days: ?Number, hours: ?Number})</code> | <code>{   "years": 1 }</code> | *optional*. Used to set the cookie expiration |
+| **cookiePath** | <code>String</code> |  | *optional*. Used to set the cookie path |
 | **dismissOnScroll** | <code>Boolean</code> | <code>true</code> | *optional*. Whether the cookie banner should be dismissed on scroll or not |
 | **dismissOnScrollThreshold** | <code>Number</code> | <code>0</code> | *optional*.   amount of pixel the user need to scroll to dismiss the cookie banner |
 | **closeIcon** | <code>String</code> |  | *optional*. ClassName passed to close-icon |


### PR DESCRIPTION
Here is a proposal to add a new "cookiePath" property.

This new property would fix a weird bug on IE: on my SPA (which uses react-router with history API), when the user clicks on the banner to close it, then navigate to another page, sometimes the cookie vanish and the banner is displayed again.

I think the bug is related to this: http://stackoverflow.com/questions/8292449/internet-explorer-sends-the-wrong-cookie-when-the-paths-overlap#8314164

If i force the cookie path to '/', i dont have the bug (and browser-cookie-lite does not force it). So this property let me set the path i wish.

I did not set a default value to not break the current behavior.