### PR TITLE
Remove unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "dependencies": {
     "classnames": "2.2.5",
     "lodash.omit": "^4.5.0",
-    "react-addons-clone-with-props": "^0.14.8",
     "react-cookie": "^2.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
I don't think `react-addons-clone-with-props` is used anywhere in this project, but this dependency has a peer dependency to react 0.14.8